### PR TITLE
Add server-based bag loading

### DIFF
--- a/lib/features/bags/bags_bloc.dart
+++ b/lib/features/bags/bags_bloc.dart
@@ -17,6 +17,15 @@ class BagsBloc extends ChangeNotifier {
     }
   }
 
+  Future<void> loadFromServer(Uri uri, {String? authToken}) async {
+    try {
+      bags = await repo.fetchFromServer(uri, authToken: authToken);
+      notifyListeners();
+    } catch (_) {
+      rethrow;
+    }
+  }
+
   void markScanned(String code) {
     for (final bag in bags) {
       if (bag.sscc == code || bag.czPrefixes.contains(code)) {

--- a/lib/features/bags/data/bag_repository.dart
+++ b/lib/features/bags/data/bag_repository.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 import 'package:excel/excel.dart';
 import '../domain/entities.dart';
 
@@ -21,5 +23,17 @@ class BagRepository {
       bag.items.add(BagItem(article: article, title: title, czPrefix: cz));
     }
     return map.values.toList();
+  }
+
+  Future<List<Bag>> fetchFromServer(Uri uri, {String? authToken}) async {
+    final response = await http.get(uri,
+        headers: {if (authToken != null) 'Authorization': authToken});
+    if (response.statusCode != 200) {
+      throw HttpException('Failed to load bags: ${response.statusCode}');
+    }
+    final List data = json.decode(response.body) as List;
+    return data
+        .map((e) => Bag.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/lib/features/bags/domain/entities.dart
+++ b/lib/features/bags/domain/entities.dart
@@ -4,6 +4,15 @@ class BagItem {
   final String czPrefix;
 
   BagItem({required this.article, required this.title, required this.czPrefix});
+
+  factory BagItem.fromJson(Map<String, dynamic> json) => BagItem(
+        article: json['article'] as String? ?? '',
+        title: json['title'] as String? ?? '',
+        czPrefix: json['czPrefix'] as String? ?? '',
+      );
+
+  Map<String, dynamic> toJson() =>
+      {'article': article, 'title': title, 'czPrefix': czPrefix};
 }
 
 class Bag {
@@ -18,4 +27,20 @@ class Bag {
     required this.items,
     this.scanned = false,
   });
+
+  factory Bag.fromJson(Map<String, dynamic> json) => Bag(
+        sscc: json['sscc'] as String? ?? '',
+        czPrefixes: List<String>.from(json['czPrefixes'] ?? const []),
+        items: (json['items'] as List? ?? [])
+            .map((e) => BagItem.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        scanned: json['scanned'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'sscc': sscc,
+        'czPrefixes': czPrefixes,
+        'items': items.map((e) => e.toJson()).toList(),
+        'scanned': scanned,
+      };
 }

--- a/lib/features/bags/presentation/bag_list_screen.dart
+++ b/lib/features/bags/presentation/bag_list_screen.dart
@@ -17,8 +17,8 @@ class BagListScreen extends StatefulWidget {
 }
 
 class _BagListScreenState extends State<BagListScreen> {
-  static const _filePath =
-      r'\\194.32.248.34\Public\умные таблицы\АВТОПРИЕМКА\МАТРЕШКА К ПРИЕМКЕ\Матрешка 330738_ИП_Арутюнянц_FIRST .xlsx';
+  static const _endpoint = 'http://194.32.248.34:51000/bags';
+  static const _authHeader = 'HvkhvUVUhvuvuYVUKvukyV';
 
   @override
   void initState() {
@@ -29,7 +29,7 @@ class _BagListScreenState extends State<BagListScreen> {
   Future<void> _loadDefaultFile() async {
     final bloc = context.read<BagsBloc>();
     try {
-      await bloc.loadFromFile(File(_filePath));
+      await bloc.loadFromServer(Uri.parse(_endpoint), authToken: _authHeader);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- allow backend to provide bag list via `/bags` endpoint
- parse bags from JSON and fetch them in the app
- update bag domain entities with (de)serialization helpers
- add Bloc method to load bags from server
- default bag screen now loads from HTTP instead of local path

## Testing
- `python3 -m py_compile server/Server_stable.py`
- `dart --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841863a1c2483248edfbe33d522748e